### PR TITLE
Fixes #946. Handles maintenance messages.

### DIFF
--- a/sfmutils/warc_iter.py
+++ b/sfmutils/warc_iter.py
@@ -66,8 +66,9 @@ class BaseWarcIter:
                         while line:
                             json_obj = None
                             try:
-                                # A non-line-oriented payload only has one payload part.
-                                json_obj = json.loads(line)
+                                if line != "\r\n":
+                                    # A non-line-oriented payload only has one payload part.
+                                    json_obj = json.loads(line)
                             except ValueError:
                                 log.warning("Bad json in record %s: %s", record_id, line)
                             if json_obj:


### PR DESCRIPTION
To test, create an export from a twitter filter collection. Following the sfm_twitterstreamexporter_1 log can be useful. If successful, the export will be as normal (this was never a problem) and there will be no "bad json" warnings in the log.