### PR TITLE
Less verbose logging of state store

### DIFF
--- a/sfmutils/state_store.py
+++ b/sfmutils/state_store.py
@@ -47,7 +47,7 @@ class DictHarvestStateStore:
         :param value: Value for the state that is being stored.  None to delete an existing value.
         """
         if self.verbose:
-            log.debug("Setting state for %s with key %s to %s", resource_type, key, value)
+            log.debug("Setting state for %s with key %s to %.200s", resource_type, key, value)
         if value is not None:
             if resource_type not in self.state:
                 self.state[resource_type] = {}

--- a/sfmutils/state_store.py
+++ b/sfmutils/state_store.py
@@ -133,4 +133,4 @@ class DelayedSetStateStoreAdapter:
         for resource_type, key_values in self.delayed_state.state.items():
             for key, value in key_values.items():
                 self.state_store.set_state(resource_type, key, value)
-        self.delayed_state = DictHarvestStateStore()
+        self.delayed_state = DictHarvestStateStore(verbose=False)


### PR DESCRIPTION
- in DelayedSetStateStore: re-create delayed store with disabled verbose logging
- limit the length of logged values: avoids overlong log messages with custom harvesters when the state store holds objects with a long string representation