### PR TITLE
warcprox URL to include scheme

### DIFF
--- a/sfmutils/warcprox.py
+++ b/sfmutils/warcprox.py
@@ -107,8 +107,8 @@ class warced:
         return self
 
     def _set_envs(self):
-        os.environ["HTTP_PROXY"] = "localhost:{}".format(self.port)
-        os.environ["HTTPS_PROXY"] = "localhost:{}".format(self.port)
+        os.environ["HTTP_PROXY"] = "http://localhost:{}".format(self.port)
+        os.environ["HTTPS_PROXY"] = "https://localhost:{}".format(self.port)
         os.environ["REQUESTS_CA_BUNDLE"] = self.ca_bundle
 
     def _unset_envs(self):


### PR DESCRIPTION
The URL pointing to the running warcprox instance set via environment variable `HTTP_PROXY` should include a scheme (http:// resp. https://). Otherwise more recent version of the urllib3 will fail to request content via the proxy. Afaics, the urlib version bundled with 3.5.2 also accepts fully qualified proxy URLs.